### PR TITLE
build: streamline builder containers

### DIFF
--- a/container/centos-stream8/Dockerfile
+++ b/container/centos-stream8/Dockerfile
@@ -1,20 +1,34 @@
-FROM quay.io/centos/centos:stream8
-ARG UID=1000
-ARG GID=1000
-ARG NODEJS_VERSION=20
-ARG BRANCH=stream-nodejs-20-rhel-8.9.0
-RUN groupadd -g $GID mock
-RUN useradd -d /home/mockbuild -m -g $GID -u $UID -s /bin/bash mockbuild
-RUN dnf install -y dnf-plugins-core git rpm-build libicu-devel
-RUN dnf config-manager -y --set-enabled powertools && \
+# Copyright Red Hat
+
+# "common" takes no build args so it can be cached between different variants.
+FROM quay.io/centos/centos:stream8 as common
+RUN dnf install -y dnf-plugins-core rpm-build libicu-devel && \
+  dnf config-manager -y --set-enabled powertools && \
   dnf install -y epel-release epel-next-release && \
-  dnf install -y centpkg dumb-init
-RUN dnf module enable -y nodejs:$NODEJS_VERSION
-RUN cd /tmp && \
+  dnf clean -y all
+
+FROM common as builder
+ARG BRANCH=stream-nodejs-20-rhel-8.9.0
+ARG NODEJS_VERSION=20
+RUN dnf install -y centpkg && \
+  dnf module enable -y nodejs:$NODEJS_VERSION && \
+  dnf clean -y all && \
+  cd /tmp && \
   git clone https://gitlab.com/redhat/centos-stream/rpms/nodejs.git -b $BRANCH && \
   cd /tmp/nodejs && \
   centpkg srpm -- --with=bundled && \
   mv nodejs-*.src.rpm / && \
-  dnf builddep -y /nodejs*.src.rpm && \
   rm -rf /tmp/nodejs
+
+FROM common
+ARG UID=1000
+ARG GID=1000
+ARG NODEJS_VERSION=20
+COPY --from=builder /nodejs-*.src.rpm /
+RUN groupadd -g $GID mock && \
+  useradd -d /home/mockbuild -m -g $GID -u $UID -s /bin/bash mockbuild && \
+  dnf install -y dumb-init && \
+  dnf module enable -y nodejs:$NODEJS_VERSION && \
+  dnf builddep -y /nodejs*.src.rpm && \
+  dnf clean -y all
 ENTRYPOINT [ "/usr/bin/dumb-init", "--" ]

--- a/container/centos-stream8/Dockerfile
+++ b/container/centos-stream8/Dockerfile
@@ -9,9 +9,7 @@ RUN dnf install -y dnf-plugins-core rpm-build libicu-devel && \
 
 FROM common as builder
 ARG BRANCH=stream-nodejs-20-rhel-8.9.0
-ARG NODEJS_VERSION=20
 RUN dnf install -y centpkg && \
-  dnf module enable -y nodejs:$NODEJS_VERSION && \
   dnf clean -y all && \
   cd /tmp && \
   git clone https://gitlab.com/redhat/centos-stream/rpms/nodejs.git -b $BRANCH && \

--- a/container/centos-stream9/Dockerfile
+++ b/container/centos-stream9/Dockerfile
@@ -1,20 +1,34 @@
-FROM quay.io/centos/centos:stream9
-ARG UID=1000
-ARG GID=1000
-ARG NODEJS_VERSION=20
-ARG BRANCH=stream-nodejs-20-rhel-9.3.0
-RUN groupadd -g $GID mock
-RUN useradd -d /home/mockbuild -m -g $GID -u $UID -s /bin/bash mockbuild
-RUN dnf install -y dnf-plugins-core git rpm-build libicu-devel python-unversioned-command
-RUN dnf config-manager -y --set-enabled crb && \
+# Copyright Red Hat
+
+# "common" takes no build args so it can be cached between different variants.
+FROM quay.io/centos/centos:stream9 as common
+RUN dnf install -y dnf-plugins-core rpm-build libicu-devel python-unversioned-command && \
+  dnf config-manager -y --set-enabled crb && \
   dnf install -y epel-release epel-next-release && \
-  dnf install -y centpkg dumb-init
-RUN dnf module enable -y nodejs:$NODEJS_VERSION
-RUN cd /tmp && \
+  dnf clean -y all
+
+FROM common as builder
+ARG BRANCH=stream-nodejs-20-rhel-9.3.0
+ARG NODEJS_VERSION=20
+RUN dnf install -y git centpkg && \
+  dnf module enable -y nodejs:$NODEJS_VERSION && \
+  dnf clean -y all && \
+  cd /tmp && \
   git clone https://gitlab.com/redhat/centos-stream/rpms/nodejs.git -b $BRANCH && \
   cd /tmp/nodejs && \
   centpkg srpm -- --with=bundled && \
   mv nodejs-*.src.rpm / && \
-  dnf builddep -y /nodejs*.src.rpm && \
   rm -rf /tmp/nodejs
+
+FROM common
+ARG UID=1000
+ARG GID=1000
+ARG NODEJS_VERSION=20
+COPY --from=builder /nodejs-*.src.rpm /
+RUN groupadd -g $GID mock && \
+  useradd -d /home/mockbuild -m -g $GID -u $UID -s /bin/bash mockbuild && \
+  dnf install -y dumb-init && \
+  dnf module enable -y nodejs:$NODEJS_VERSION && \
+  dnf builddep -y /nodejs*.src.rpm && \
+  dnf clean -y all
 ENTRYPOINT [ "/usr/bin/dumb-init", "--" ]

--- a/container/centos-stream9/Dockerfile
+++ b/container/centos-stream9/Dockerfile
@@ -9,9 +9,7 @@ RUN dnf install -y dnf-plugins-core rpm-build libicu-devel python-unversioned-co
 
 FROM common as builder
 ARG BRANCH=stream-nodejs-20-rhel-9.3.0
-ARG NODEJS_VERSION=20
 RUN dnf install -y git centpkg && \
-  dnf module enable -y nodejs:$NODEJS_VERSION && \
   dnf clean -y all && \
   cd /tmp && \
   git clone https://gitlab.com/redhat/centos-stream/rpms/nodejs.git -b $BRANCH && \


### PR DESCRIPTION
Use multi-stage builds to shrink the size of the final containers. 
Extract common `RUN` steps to a `common` layer which can be cached and reused between `docker build` invocations, slightly speeding up building the containers.