### PR TITLE
feat: record start time

### DIFF
--- a/lib/internal/redhat/insights.js
+++ b/lib/internal/redhat/insights.js
@@ -46,8 +46,9 @@ function writeInsightsData() {
 
 function initializeInsights() {
   if (initializeImmediate) return;
+  const startTime = Date.now();
   const { processId, commandLine, nodejsVersion, arch } = process.report.getReport().header;
-  constantData = { ...constantData, processId, commandLine, nodejsVersion, arch };
+  constantData = { ...constantData, processId, commandLine, nodejsVersion, arch, startTime };
   uploadArchiveDir = process.env['RHT_INSIGHTS_JS_ARCHIVE_UPLOAD_DIR'];
   initializeImmediate = setImmediate(() => { writeInsightsData(); });
   process.once('beforeExit', () => { clearImmediate(initializeImmediate); });

--- a/test/common/utils.mjs
+++ b/test/common/utils.mjs
@@ -8,6 +8,7 @@ const expectedTypes = new Map([
   [ 'id', 'string' ],
   [ 'nodejsVersion', 'string' ],
   [ 'processId', 'number' ],
+  [ 'startTime', 'number' ],
   [ 'rhInsightsVersion', 'string' ],
 ]);
 


### PR DESCRIPTION
Record time when the client initializes and include in the data. This should be reasonably close to the `node_start_time`, which isn't available to the Javascript layer in Node.js.