### PR TITLE
fix: rename `date` to `reportTime`

### DIFF
--- a/lib/internal/redhat/insights.js
+++ b/lib/internal/redhat/insights.js
@@ -12,8 +12,8 @@ let initializeImmediate;
 let uploadArchiveDir;
 
 function writeInsightsData() {
-  const date = new Date().toISOString();
-  const data = JSON.stringify({ date, ...constantData});
+  const reportTime = Date.now();
+  const data = JSON.stringify({ reportTime, ...constantData});
   if (debug.enabled) {
     debug(`Red Hat Insights ${RH_INSIGHTS_VERSION}`);
     debug(`Payload ${data}`);

--- a/test/common/utils.mjs
+++ b/test/common/utils.mjs
@@ -4,10 +4,10 @@ import assert from 'node:assert';
 const expectedTypes = new Map([
   [ 'arch', 'string' ],
   [ 'commandLine', 'object' ],
-  [ 'date', 'string' ],
   [ 'id', 'string' ],
   [ 'nodejsVersion', 'string' ],
   [ 'processId', 'number' ],
+  [ 'reportTime', 'number' ],
   [ 'startTime', 'number' ],
   [ 'rhInsightsVersion', 'string' ],
 ]);

--- a/test/integration/test-file.mjs
+++ b/test/integration/test-file.mjs
@@ -54,6 +54,10 @@ test('file is written', async () => {
   assert.strictEqual(data.nodejsVersion, process.version);
   assert.strictEqual(data.arch, process.arch);
   utils.validate(data);
+  assert(data.startTime <= data.reportTime);
+  // Timestamps should be time in milliseconds since UNIX epoch.
+  assert.strictEqual(new Date(data.startTime).valueOf(), data.startTime);
+  assert.strictEqual(new Date(data.reportTime).valueOf(), data.reportTime);
 });
 test('upload dir cannot be created', async () => {
   const opts = {

--- a/test/unit/test-file.mjs
+++ b/test/unit/test-file.mjs
@@ -62,6 +62,10 @@ test('file is written', async () => {
   assert.strictEqual(data.nodejsVersion, process.version);
   assert.strictEqual(data.arch, process.arch);
   utils.validate(data);
+  assert(data.startTime <= data.reportTime);
+  // Timestamps should be time in milliseconds since UNIX epoch.
+  assert.strictEqual(new Date(data.startTime).valueOf(), data.startTime);
+  assert.strictEqual(new Date(data.reportTime).valueOf(), data.reportTime);
 });
 test('upload dir cannot be created', async () => {
   const opts = {


### PR DESCRIPTION
For consistency with `startTime`, record the timestamp of the report as a timestamp (number of milliseconds since the UNIX epoch) instead of as a formatted date.