### PR TITLE
ci: minimize GitHub Actions cache usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ on:
   pull_request:
   push:
     branches: [master]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -55,4 +57,5 @@ jobs:
     with:
       centos_stream_version: ${{ matrix.centos_stream_version }}
       nodejs_version: ${{ matrix.nodejs_version }}
+      restore_ccache: ${{ github.event_name != 'schedule' }}
     secrets: inherit

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,10 @@ on:
         default: "20"
         type: string
         required: true
+      restore_ccache:
+        default: true
+        required: true
+        type: boolean
 
 jobs:
   build-rpms:
@@ -27,6 +31,7 @@ jobs:
           key: centos-stream-${{ inputs.centos_stream_version }}-nodejs-${{ inputs.nodejs_version }}-${{ github.base_ref || github.ref_name }}
           restore-keys: |
             centos-stream-${{ inputs.centos_stream_version }}-nodejs-${{ inputs.nodejs_version }}-${{ github.base_ref || github.ref_name }}
+          restore: ${{ inputs.restore_ccache }}
           save: ${{ github.event.number == '' }}
       - name: Build container insights-js-client-builder:nodejs-${{ inputs.nodejs_version}}.el${{ inputs.centos_stream_version }}
         run: ./scripts/buildcontainer.sh "${{ inputs.centos_stream_version }}" "${{ inputs.nodejs_version }}"


### PR DESCRIPTION
Schedule a daily build that saves but does not restore ccache to prevent excessive cache growth when Node.js is updated in CentOS Stream/RHEL.