### PR TITLE
ci: switch CentOS Stream 8 to use vault.centos.org

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,6 +64,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Patch for archived CentOS Stream 8
+        if: ${{ inputs.centos_stream_version == '8' }}
+        run: |
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
       - uses: actions/download-artifact@v4
         with:
           name: rpms-nodejs${{ inputs.nodejs_version }}.el${{ inputs.centos_stream_version }}

--- a/container/centos-stream8/Dockerfile
+++ b/container/centos-stream8/Dockerfile
@@ -2,7 +2,9 @@
 
 # "common" takes no build args so it can be cached between different variants.
 FROM quay.io/centos/centos:stream8 as common
-RUN dnf install -y dnf-plugins-core rpm-build libicu-devel && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+  dnf install -y dnf-plugins-core rpm-build libicu-devel && \
   dnf config-manager -y --set-enabled powertools && \
   dnf install -y epel-release epel-next-release && \
   dnf clean -y all


### PR DESCRIPTION
CentOS Stream 8 has now been archived to vault.centos.org.

Refs: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/